### PR TITLE
Use Broker::publish instead of Cluster::publish

### DIFF
--- a/scripts/main.zeek
+++ b/scripts/main.zeek
@@ -71,9 +71,11 @@ function add_host(a: addr)
         add used_address_space[masked];
         event Site::new_used_address_space(masked);
         @if ( Cluster::is_enabled() )
-        local e = Cluster::make_event(Site::new_used_address_space, masked);
-        Cluster::publish(Cluster::manager_topic, e);
-        Cluster::publish(Cluster::proxy_topic, e);
+        # Modern Zeek: Use Broker::publish instead of Cluster::make_event or Cluster::publish.
+        Broker::publish(Cluster::manager_topic,
+                Site::new_used_address_space, masked);
+        Broker::publish(Cluster::proxy_topic,
+                Site::new_used_address_space, masked);
         @endif
         NOTICE([$note=New_Used_Address_Space,
                 $identifier=fmt("%s",masked),


### PR DESCRIPTION
Update add_host in scripts/main.zeek to use Broker::publish for publishing Site::new_used_address_space events to Cluster::manager_topic and Cluster::proxy_topic. Removes the older Cluster::make_event/Cluster::publish calls in favor of the modern Broker API while keeping the Cluster::is_enabled() guard.

All research glory goes to Brett Warrick.